### PR TITLE
fix: build시 text-shadow 적용이 반대로 되던 문제 해결

### DIFF
--- a/src/lib/components/Timetable.module.scss
+++ b/src/lib/components/Timetable.module.scss
@@ -117,7 +117,7 @@
   box-shadow: 0px 8px 12px rgba(0, 0, 0, 0.3);
   color: #333;
   box-sizing: border-box;
-  text-shadow: none;
+  text-shadow: none !important;
 }
 
 .buttonLayout {


### PR DESCRIPTION
빌드 후에는 의도했던 출력이 제대로 되지 않았습니다. 따라서 !important설정을 넣어 우선적으로 해당 속성을 따르게 변경했습니다.