### PR TITLE
build: dependencies 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,11 @@
     "lint": "eslint .",
     "preview": "vite preview"
   },
+  "dependencies": {
+    "@floating-ui/react": "^0.26.22",
+    "date-fns": "^3.6.0",
+    "randomcolor": "^0.6.2"
+  },
   "peerDependencies": {
     "@floating-ui/react": "^0.26.22",
     "date-fns": "^3.6.0",


### PR DESCRIPTION
peer dependencies에 있던 의존성을 react, react-dom을 제외하고 dependencies로 옮겼습니다.