### PR TITLE
feat: jest vscode exension setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@ dist-ssr
 *.local
 
 # Editor directories and files
-.vscode/*
-!.vscode/extensions.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "search.exclude": {
+    "**/.yarn": true,
+    "**/.pnp.*": true
+  },
+  "eslint.nodePath": ".yarn/sdks",
+  "prettier.prettierPath": ".yarn/sdks/prettier/index.cjs",
+  "typescript.tsdk": ".yarn/sdks/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "jest.runMode": "on-save",
+
+  "jest.virtualFolders": [{ "name": "library", "rootPath": "./library" }]
+}


### PR DESCRIPTION
- Close #21 

## What is this PR? 🔍

- 기능 :
vscode의 jest extension을 사용할 수 있게 설정을 변경했습니다.
- issue : #21 

## Changes 📝
- jest 세팅은 이미 되어있었습니다. vscode에서 library 폴더를 기준으로 `yarn test`, `yarn test --watch`등이 동작하는걸 확인했습니다.
- vscode jest extension을 사용할 수 있게 설정을 추가했습니다. [참고 링크](https://kernel360.github.io/blog/vscode-jest-extension-with-monorepo)

<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->